### PR TITLE
Add `get book by isbn` endpoint

### DIFF
--- a/src/main/java/com/team23/geektext/book/BookController.java
+++ b/src/main/java/com/team23/geektext/book/BookController.java
@@ -3,10 +3,12 @@ package com.team23.geektext.book;
 import com.team23.geektext.exception.AuthorNotFoundException;
 import com.team23.geektext.exception.DuplicateIsbnException;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,5 +50,15 @@ public class BookController {
                     .contentType(MediaType.APPLICATION_JSON)
                     .body("An unexpected error occurred.");
         }
+    }
+
+    @GetMapping("/{isbn}")
+    public ResponseEntity<?> getBookByIsbn(@PathVariable String isbn) {
+        Optional<Book> bookOptional = bookService.getBookByIsbn(isbn);
+        if (bookOptional.isEmpty()) {
+            String errorMessage = "The requested book with ISBN '" + isbn + "' does not exist.";
+            return new ResponseEntity<String>(errorMessage, HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<Book>(bookOptional.get(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/team23/geektext/book/BookService.java
+++ b/src/main/java/com/team23/geektext/book/BookService.java
@@ -5,6 +5,7 @@ import com.team23.geektext.exception.DuplicateIsbnException;
 import com.team23.geektext.repository.AuthorRepository;
 import com.team23.geektext.repository.BookRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,5 +32,9 @@ public class BookService {
                     "A book with ISBN '" + book.getIsbn() + "' already exists.");
         }
         return bookRepository.save(book);
+    }
+
+    public Optional<Book> getBookByIsbn(String isbn) {
+        return bookRepository.findByIsbn(isbn);
     }
 }

--- a/src/main/java/com/team23/geektext/repository/BookRepository.java
+++ b/src/main/java/com/team23/geektext/repository/BookRepository.java
@@ -1,9 +1,14 @@
 package com.team23.geektext.repository;
 
 import com.team23.geektext.book.Book;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface BookRepository extends JpaRepository<Book, UUID> {
     boolean existsByIsbn(String isbn);
+
+    Optional<Book> findByIsbn(String isbn);
 }


### PR DESCRIPTION
### Summary

This pull request introduces a `GET` endpoint to retrieve a book by its International Standard Book Number (ISBN). This enhancement provides clients with the ability to fetch book details based on their unique ISBN identifier.

### Changes

- **BookController:** Added a new `GET` endpoint for retrieving a book by ISBN.
- **BookService:** Implemented a service method to fetch a book by its ISBN.
- **BookRepository:** Implemented `findByIsbn` method to fetch a book by its ISBN.
- **Tests:** Added unit tests to ensure the endpoint functions correctly.

### Endpoint Details

- **Purpose:** Allows clients to retrieve book details by providing the ISBN.
- **Endpoint:** `/api/books/{isbn}`
- **HTTP Method:** `GET`
- **Parameters:**
  - `isbn` (Path Parameter): The ISBN of the book to retrieve.
- **Response:** Returns a JSON object containing the book details if found or a "Not Found" response if the book with the specified ISBN does not exist.
- **Example Response (Book Found):**
  ```json
  {
    "isbn": "978-0545790352",
    "name": "Harry Potter and the Sorcerer's Stone",
    "description": "Fantasy novel",
    "price": 19.99,
    "authorId": "some-author-id",
    "genre": "Fantasy",
    "publisher": "Bloomsbury Publishing",
    "yearPublished": 1997,
    "copiesSold": 1000000
  }
  ```
- **Example Response (Book Not Found):**
  ```
   The requested book with ISBN 'isbn-weird' does not exist.
  ```

### Test Cases
- Retrieve a book by a valid ISBN.
- Attempt to retrieve a book with a non-existent ISBN.
- Verify the response structure and data accuracy in both cases.

### How to Test
- Pull the branch to your local setup.
- Run the application.
- Use a tool like `curl` or Postman to test the endpoint.

Example Curl Command:
```bash
curl -X GET "http://localhost:8080/api/books/{isbn}"
```